### PR TITLE
Configure Pinecone environment for RAG tools

### DIFF
--- a/fasal-setu-ai/.env.example
+++ b/fasal-setu-ai/.env.example
@@ -3,3 +3,5 @@ SERVER_PORT=3000
 AI_ENGINE_URL=http://localhost:7001
 DECISION_ENGINE_URL=http://localhost:7002
 LLM2_URL=http://localhost:7003
+PINECONE_API_KEY=your-pinecone-api-key
+PINECONE_ENV=your-pinecone-environment

--- a/fasal-setu-ai/py/ai_engine/tools/build_index.py
+++ b/fasal-setu-ai/py/ai_engine/tools/build_index.py
@@ -30,7 +30,7 @@ INDEX_NAME = "rag-index"
 
 # Pinecone API key and environment should be set as env vars
 PINECONE_API_KEY = os.environ.get("PINECONE_API_KEY")
-PINECONE_ENV = os.environ.get("PINECONE_ENV", "gcp-starter")
+PINECONE_ENV = os.environ.get("PINECONE_ENV", "us-central1")
 
 def get_all_json_files(data_dir: Path) -> List[Path]:
 	files = []
@@ -78,18 +78,18 @@ def embed_and_upsert(chunks: List[Dict[str, Any]], index):
 
 
 def main():
-	if not PINECONE_API_KEY:
-		raise RuntimeError("PINECONE_API_KEY not set in environment.")
-	pc = Pinecone(api_key=PINECONE_API_KEY)
-	# Check/create index
-	if INDEX_NAME not in [idx.name for idx in pc.list_indexes()]:
-		pc.create_index(
-			name=INDEX_NAME,
-			dimension=1024,  # Make sure this matches your embedding size
-			metric="cosine",
-			spec=ServerlessSpec(cloud="gcp", region="us-central1")
-		)
-	index = pc.Index(INDEX_NAME)
+        if not PINECONE_API_KEY:
+                raise RuntimeError("PINECONE_API_KEY not set in environment.")
+        pc = Pinecone(api_key=PINECONE_API_KEY, environment=PINECONE_ENV)
+        # Check/create index
+        if INDEX_NAME not in [idx.name for idx in pc.list_indexes()]:
+                pc.create_index(
+                        name=INDEX_NAME,
+                        dimension=1024,  # Make sure this matches your embedding size
+                        metric="cosine",
+                        spec=ServerlessSpec(cloud="gcp", region=PINECONE_ENV)
+                )
+        index = pc.Index(INDEX_NAME)
 	files = get_all_json_files(DATA_DIR)
 	print(f"Found {len(files)} files.")
 	for file_path in files:

--- a/fasal-setu-ai/py/ai_engine/tools/rag_search.py
+++ b/fasal-setu-ai/py/ai_engine/tools/rag_search.py
@@ -40,7 +40,7 @@ def rag_search(args: Dict[str, Any]) -> Dict[str, Any]:
         return {"data": [], "source_stamp": "no_query"}
     if not PINECONE_API_KEY:
         raise RuntimeError("PINECONE_API_KEY not set in environment.")
-    pc = Pinecone(api_key=PINECONE_API_KEY)
+    pc = Pinecone(api_key=PINECONE_API_KEY, environment=PINECONE_ENV)
     index = pc.Index(INDEX_NAME)
     query_vec = embed_query(query)
     res = index.query(vector=query_vec, top_k=top_k, include_metadata=True)


### PR DESCRIPTION
## Summary
- Pass `environment=PINECONE_ENV` when creating the Pinecone client in RAG search and index-building tools
- Use env-provided region for serverless Pinecone index creation
- Document `PINECONE_API_KEY` and `PINECONE_ENV` in `.env.example`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e232b6ff88331a952e70d692dbda3