### PR TITLE
Propagate source metadata for RAG passages

### DIFF
--- a/fasal-setu-ai/py/ai_engine/tools/build_index.py
+++ b/fasal-setu-ai/py/ai_engine/tools/build_index.py
@@ -4,11 +4,11 @@ build_index.py: Ingests all static JSON/text files from data/static_json/, chunk
 """
 import os
 import json
-import os
 from pathlib import Path
 from typing import List, Dict, Any
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from dotenv import load_dotenv
+
 load_dotenv()
 
 
@@ -16,12 +16,12 @@ load_dotenv()
 
 # Use HuggingFaceEmbeddings for free, local embedding
 try:
-	from langchain_community.embeddings import HuggingFaceEmbeddings
+        from langchain_community.embeddings import HuggingFaceEmbeddings
 except ImportError:
 	raise ImportError("Please install langchain-community: pip install langchain-community")
 
 try:
-	from pinecone import Pinecone, ServerlessSpec
+        from pinecone import Pinecone, ServerlessSpec
 except ImportError:
 	raise ImportError("Pinecone v7+ SDK is required. Please install with: pip install 'pinecone[grpc]'")
 
@@ -41,35 +41,58 @@ def get_all_json_files(data_dir: Path) -> List[Path]:
 	return files
 
 def load_and_chunk_json(file_path: Path, chunk_size=1024, chunk_overlap=100) -> List[Dict[str, Any]]:
-	"""Load JSON and chunk by top-level array/object or recursively by text."""
-	with open(file_path, "r", encoding="utf-8") as f:
-		data = json.load(f)
-	# If it's a list of dicts, treat each as a chunk
-	if isinstance(data, list):
-		return [{"text": json.dumps(item, ensure_ascii=False), "source": str(file_path)} for item in data]
-	# If it's a dict, chunk by keys or by text
-	elif isinstance(data, dict):
-		chunks = []
-		for k, v in data.items():
-			if isinstance(v, str) and len(v) > chunk_size:
-				splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
-				for chunk in splitter.split_text(v):
-					chunks.append({"text": chunk, "source": f"{file_path}:{k}"})
-			else:
-				chunks.append({"text": json.dumps({k: v}, ensure_ascii=False), "source": f"{file_path}:{k}"})
-		return chunks
-	else:
-		# Fallback: treat as a single chunk
-		return [{"text": json.dumps(data, ensure_ascii=False), "source": str(file_path)}]
+        """Load JSON and chunk by top-level array/object or recursively by text.
+
+        Each returned chunk includes basic source metadata so it can be stored with
+        the vector and later surfaced in search results.
+        """
+        with open(file_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+
+        # Basic metadata derived from the file. These can be overridden by chunk data
+        # if more specific values exist.
+        base_meta = {
+                "title": file_path.stem,
+                "url": "",
+                "date": "",
+        }
+
+        # If it's a list of dicts, treat each as a chunk
+        if isinstance(data, list):
+                return [
+                        {"text": json.dumps(item, ensure_ascii=False), "source": str(file_path), **base_meta}
+                        for item in data
+                ]
+        # If it's a dict, chunk by keys or by text
+        elif isinstance(data, dict):
+                chunks = []
+                for k, v in data.items():
+                        if isinstance(v, str) and len(v) > chunk_size:
+                                splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+                                for chunk in splitter.split_text(v):
+                                        chunks.append({"text": chunk, "source": f"{file_path}:{k}", **base_meta})
+                        else:
+                                chunks.append({"text": json.dumps({k: v}, ensure_ascii=False), "source": f"{file_path}:{k}", **base_meta})
+                return chunks
+        else:
+                # Fallback: treat as a single chunk
+                return [{"text": json.dumps(data, ensure_ascii=False), "source": str(file_path), **base_meta}]
 
 def embed_and_upsert(chunks: List[Dict[str, Any]], index):
 	embedder = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
 	batch = []
 	for i, chunk in enumerate(chunks):
-		text = chunk["text"]
-		source = chunk["source"]
-		embedding = embedder.embed_query(text)
-		batch.append({"id": f"{source}-{i}", "values": embedding, "metadata": {"source": source, "text": text}})
+                text = chunk["text"]
+                source = chunk["source"]
+                embedding = embedder.embed_query(text)
+                metadata = {
+                        "source": source,
+                        "text": text,
+                        "title": chunk.get("title", ""),
+                        "url": chunk.get("url", ""),
+                        "date": chunk.get("date", ""),
+                }
+                batch.append({"id": f"{source}-{i}", "values": embedding, "metadata": metadata})
 		if len(batch) >= 32:
 			index.upsert(vectors=batch)
 			batch = []
@@ -96,7 +119,8 @@ def main():
 		print(f"Processing {file_path}")
 		chunks = load_and_chunk_json(file_path)
 		embed_and_upsert(chunks, index)
-	print("Ingestion complete.")
+        print("Ingestion complete.")
 
 if __name__ == "__main__":
-	main()
+        main()
+

--- a/fasal-setu-ai/py/ai_engine/tools/rag_search.py
+++ b/fasal-setu-ai/py/ai_engine/tools/rag_search.py
@@ -32,7 +32,15 @@ def rag_search(args: Dict[str, Any]) -> Dict[str, Any]:
         query: str
         top_k: int (default 5)
     Returns:
-        {data: [{text, source_stamp}], source_stamp}
+        {
+            data: [
+                {
+                    text: str,
+                    source_stamp: {"title": str, "url": str, "date": str}
+                }
+            ],
+            source_stamp: str
+        }
     """
     query = args.get("query")
     top_k = args.get("top_k", 5)
@@ -51,8 +59,14 @@ def rag_search(args: Dict[str, Any]) -> Dict[str, Any]:
     passages = []
     for match in matches or []:
         meta = match.get("metadata", {})
-        passages.append({
-            "text": meta.get("text", ""),
-            "source_stamp": meta.get("source", "")
-        })
+        passages.append(
+            {
+                "text": meta.get("text", ""),
+                "source_stamp": {
+                    "title": meta.get("title", ""),
+                    "url": meta.get("url", ""),
+                    "date": meta.get("date", ""),
+                },
+            }
+        )
     return {"data": passages, "source_stamp": "pinecone_rag"}


### PR DESCRIPTION
## Summary
- enrich rag_search responses with structured `source_stamp` metadata
- include title, url, and date in Pinecone vector metadata during index build

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e2330193883318d60b74585d80f9e