### PR TITLE
feat: add metadata tags and filtering

### DIFF
--- a/fasal-setu-ai/py/ai_engine/tools/build_index.py
+++ b/fasal-setu-ai/py/ai_engine/tools/build_index.py
@@ -40,41 +40,79 @@ def get_all_json_files(data_dir: Path) -> List[Path]:
 				files.append(Path(root) / fname)
 	return files
 
+def _tags_from_path(file_path: Path) -> Dict[str, str]:
+        """Derive tags like state and district from the file name."""
+        tags: Dict[str, str] = {}
+        parts = file_path.stem.split("_")
+        if parts:
+                tags["state"] = parts[0].lower()
+                if len(parts) > 1:
+                        tags["district"] = "_".join(parts[1:]).lower()
+        return tags
+
+
+def _tags_from_obj(obj: Any) -> Dict[str, str]:
+        """Extract known tags from a JSON object."""
+        tags: Dict[str, str] = {}
+        if isinstance(obj, dict):
+                if obj.get("state"):
+                        tags["state"] = str(obj["state"]).lower()
+                if obj.get("district"):
+                        tags["district"] = str(obj["district"]).lower()
+                # crop may appear as "crop" or "crop_name"
+                crop_val = obj.get("crop") or obj.get("crop_name")
+                if crop_val:
+                        tags["crop"] = str(crop_val).lower()
+        return tags
+
+
 def load_and_chunk_json(file_path: Path, chunk_size=1024, chunk_overlap=100) -> List[Dict[str, Any]]:
-	"""Load JSON and chunk by top-level array/object or recursively by text."""
-	with open(file_path, "r", encoding="utf-8") as f:
-		data = json.load(f)
-	# If it's a list of dicts, treat each as a chunk
-	if isinstance(data, list):
-		return [{"text": json.dumps(item, ensure_ascii=False), "source": str(file_path)} for item in data]
-	# If it's a dict, chunk by keys or by text
-	elif isinstance(data, dict):
-		chunks = []
-		for k, v in data.items():
-			if isinstance(v, str) and len(v) > chunk_size:
-				splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
-				for chunk in splitter.split_text(v):
-					chunks.append({"text": chunk, "source": f"{file_path}:{k}"})
-			else:
-				chunks.append({"text": json.dumps({k: v}, ensure_ascii=False), "source": f"{file_path}:{k}"})
-		return chunks
-	else:
-		# Fallback: treat as a single chunk
-		return [{"text": json.dumps(data, ensure_ascii=False), "source": str(file_path)}]
+        """Load JSON and chunk by top-level array/object or recursively by text.
+
+        Each returned chunk includes extracted tags under the "tags" key.
+        """
+        with open(file_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        base_tags = _tags_from_path(file_path)
+        # If it's a list of dicts, treat each as a chunk
+        if isinstance(data, list):
+                chunks = []
+                for item in data:
+                        tags = {**base_tags, **_tags_from_obj(item)}
+                        chunks.append({"text": json.dumps(item, ensure_ascii=False), "source": str(file_path), "tags": tags})
+                return chunks
+        # If it's a dict, chunk by keys or by text
+        elif isinstance(data, dict):
+                tags = {**base_tags, **_tags_from_obj(data)}
+                chunks = []
+                for k, v in data.items():
+                        if isinstance(v, str) and len(v) > chunk_size:
+                                splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+                                for chunk in splitter.split_text(v):
+                                        chunks.append({"text": chunk, "source": f"{file_path}:{k}", "tags": tags})
+                        else:
+                                chunk_tags = {**tags, **_tags_from_obj(v)}
+                                chunks.append({"text": json.dumps({k: v}, ensure_ascii=False), "source": f"{file_path}:{k}", "tags": chunk_tags})
+                return chunks
+        else:
+                # Fallback: treat as a single chunk
+                return [{"text": json.dumps(data, ensure_ascii=False), "source": str(file_path), "tags": base_tags}]
 
 def embed_and_upsert(chunks: List[Dict[str, Any]], index):
-	embedder = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
-	batch = []
-	for i, chunk in enumerate(chunks):
-		text = chunk["text"]
-		source = chunk["source"]
-		embedding = embedder.embed_query(text)
-		batch.append({"id": f"{source}-{i}", "values": embedding, "metadata": {"source": source, "text": text}})
-		if len(batch) >= 32:
-			index.upsert(vectors=batch)
-			batch = []
-	if batch:
-		index.upsert(vectors=batch)
+        embedder = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+        batch = []
+        for i, chunk in enumerate(chunks):
+                text = chunk["text"]
+                source = chunk["source"]
+                tags = chunk.get("tags", {})
+                embedding = embedder.embed_query(text)
+                metadata = {"source": source, "text": text, **tags}
+                batch.append({"id": f"{source}-{i}", "values": embedding, "metadata": metadata})
+                if len(batch) >= 32:
+                        index.upsert(vectors=batch)
+                        batch = []
+        if batch:
+                index.upsert(vectors=batch)
 
 
 def main():


### PR DESCRIPTION
## Summary
- extract state, district, and crop tags from JSON files and add to Pinecone metadata
- allow RAG search to accept filters and forward them to Pinecone queries

## Testing
- `pytest`
- `python -m py_compile py/ai_engine/tools/build_index.py py/ai_engine/tools/rag_search.py`


------
https://chatgpt.com/codex/tasks/task_e_689e2330c81c8331888507a552af73e8