### PR TITLE
refactor: centralize embedding utilities

### DIFF
--- a/fasal-setu-ai/py/ai_engine/tools/build_index.py
+++ b/fasal-setu-ai/py/ai_engine/tools/build_index.py
@@ -1,29 +1,18 @@
 
-"""
-build_index.py: Ingests all static JSON/text files from data/static_json/, chunks them (JSON-aware), embeds with llama-text-embed-v2, and upserts to Pinecone index.
-"""
-import os
+"""Ingest JSON/text files, embed, and upsert to a Pinecone index."""
+
 import json
 import os
 from pathlib import Path
 from typing import List, Dict, Any
+
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from dotenv import load_dotenv
+from pinecone import Pinecone, ServerlessSpec
+
+from embed_utils import embed_query, EMBEDDING_DIM
+
 load_dotenv()
-
-
-
-
-# Use HuggingFaceEmbeddings for free, local embedding
-try:
-	from langchain_community.embeddings import HuggingFaceEmbeddings
-except ImportError:
-	raise ImportError("Please install langchain-community: pip install langchain-community")
-
-try:
-	from pinecone import Pinecone, ServerlessSpec
-except ImportError:
-	raise ImportError("Pinecone v7+ SDK is required. Please install with: pip install 'pinecone[grpc]'")
 
 DATA_DIR = Path(__file__).parent.parent.parent / "data" / "static_json"
 INDEX_NAME = "rag-index"
@@ -63,18 +52,17 @@ def load_and_chunk_json(file_path: Path, chunk_size=1024, chunk_overlap=100) -> 
 		return [{"text": json.dumps(data, ensure_ascii=False), "source": str(file_path)}]
 
 def embed_and_upsert(chunks: List[Dict[str, Any]], index):
-	embedder = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
-	batch = []
-	for i, chunk in enumerate(chunks):
-		text = chunk["text"]
-		source = chunk["source"]
-		embedding = embedder.embed_query(text)
-		batch.append({"id": f"{source}-{i}", "values": embedding, "metadata": {"source": source, "text": text}})
-		if len(batch) >= 32:
-			index.upsert(vectors=batch)
-			batch = []
-	if batch:
-		index.upsert(vectors=batch)
+        batch = []
+        for i, chunk in enumerate(chunks):
+                text = chunk["text"]
+                source = chunk["source"]
+                embedding = embed_query(text)
+                batch.append({"id": f"{source}-{i}", "values": embedding, "metadata": {"source": source, "text": text}})
+                if len(batch) >= 32:
+                        index.upsert(vectors=batch)
+                        batch = []
+        if batch:
+                index.upsert(vectors=batch)
 
 
 def main():
@@ -83,12 +71,12 @@ def main():
 	pc = Pinecone(api_key=PINECONE_API_KEY)
 	# Check/create index
 	if INDEX_NAME not in [idx.name for idx in pc.list_indexes()]:
-		pc.create_index(
-			name=INDEX_NAME,
-			dimension=1024,  # Make sure this matches your embedding size
-			metric="cosine",
-			spec=ServerlessSpec(cloud="gcp", region="us-central1")
-		)
+                pc.create_index(
+                        name=INDEX_NAME,
+                        dimension=EMBEDDING_DIM,
+                        metric="cosine",
+                        spec=ServerlessSpec(cloud="gcp", region="us-central1")
+                )
 	index = pc.Index(INDEX_NAME)
 	files = get_all_json_files(DATA_DIR)
 	print(f"Found {len(files)} files.")
@@ -99,4 +87,5 @@ def main():
 	print("Ingestion complete.")
 
 if __name__ == "__main__":
-	main()
+        main()
+

--- a/fasal-setu-ai/py/ai_engine/tools/embed_utils.py
+++ b/fasal-setu-ai/py/ai_engine/tools/embed_utils.py
@@ -1,0 +1,31 @@
+"""Shared embedding utilities for RAG tools.
+
+This module centralizes embedding configuration so that scripts such as
+``build_index.py`` and ``rag_search.py`` use the exact same embedding logic.
+Currently we rely on local HuggingFace embeddings via
+``sentence-transformers/all-MiniLM-L6-v2``.
+"""
+
+from typing import List
+
+try:  # pragma: no cover - dependency is required for runtime, not tests
+    from langchain_community.embeddings import HuggingFaceEmbeddings
+except ImportError as exc:  # pragma: no cover - provide clear message
+    raise ImportError(
+        "Please install langchain-community: pip install langchain-community"
+    ) from exc
+
+
+EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+EMBEDDER = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL)
+
+
+def embed_query(text: str) -> List[float]:
+    """Return the embedding vector for *text*."""
+
+    return EMBEDDER.embed_query(text)
+
+
+# Expose the embedding dimension so index builders can stay in sync.
+EMBEDDING_DIM = len(embed_query("dimension probe"))
+

--- a/fasal-setu-ai/py/ai_engine/tools/rag_search.py
+++ b/fasal-setu-ai/py/ai_engine/tools/rag_search.py
@@ -1,53 +1,43 @@
-"""
-rag_search.py: Query Pinecone for top-k similar passages given a query, using local or Pinecone embedder.
-"""
+"""Query Pinecone for top-k similar passages using shared embeddings."""
+
 import os
-from dotenv import load_dotenv
-load_dotenv()
 from typing import Dict, Any
 
-# Use Pinecone's built-in embedder if available (v7+), else fallback to HuggingFaceEmbeddings
-try:
-    from pinecone import Pinecone, EmbeddingModel
-    EMBEDDER = EmbeddingModel.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
-    def embed_query(text):
-        return EMBEDDER.embed_documents([text])[0]
-except ImportError:
-    try:
-        from langchain_community.embeddings import HuggingFaceEmbeddings
-        EMBEDDER = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
-        def embed_query(text):
-            return EMBEDDER.embed_query(text)
-    except ImportError:
-        raise ImportError("Please install pinecone[grpc] or langchain-community: pip install pinecone[grpc] langchain-community")
+from dotenv import load_dotenv
+from pinecone import Pinecone
+
+from embed_utils import embed_query
+
+load_dotenv()
 
 INDEX_NAME = "rag-index"
 PINECONE_API_KEY = os.environ.get("PINECONE_API_KEY")
 PINECONE_ENV = os.environ.get("PINECONE_ENV", "us-east-1-aws")
-# You can find your Pinecone environment string in the Pinecone Console (https://console.pinecone.io/) under your project settings or API keys. It looks like "gcp-starter", "us-east1-gcp", "us-east-1-aws", etc.
+# You can find your Pinecone environment string in the Pinecone Console
+# (https://console.pinecone.io/) under your project settings or API keys. It
+# looks like "gcp-starter", "us-east1-gcp", "us-east-1-aws", etc.
+
 
 def rag_search(args: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Args should include:
-        query: str
-        top_k: int (default 5)
-    Returns:
-        {data: [{text, source_stamp}], source_stamp}
-    """
+    """Return passages similar to ``args['query']`` from the Pinecone index."""
+
     query = args.get("query")
     top_k = args.get("top_k", 5)
     if not query:
         return {"data": [], "source_stamp": "no_query"}
     if not PINECONE_API_KEY:
         raise RuntimeError("PINECONE_API_KEY not set in environment.")
+
     pc = Pinecone(api_key=PINECONE_API_KEY)
     index = pc.Index(INDEX_NAME)
     query_vec = embed_query(query)
     res = index.query(vector=query_vec, top_k=top_k, include_metadata=True)
+
     # Pinecone v7 returns .matches (list), or dict with "matches"
     matches = getattr(res, "matches", None)
     if matches is None and isinstance(res, dict):
         matches = res.get("matches", [])
+
     passages = []
     for match in matches or []:
         meta = match.get("metadata", {})
@@ -55,4 +45,6 @@ def rag_search(args: Dict[str, Any]) -> Dict[str, Any]:
             "text": meta.get("text", ""),
             "source_stamp": meta.get("source", "")
         })
+
     return {"data": passages, "source_stamp": "pinecone_rag"}
+


### PR DESCRIPTION
## Summary
- use shared HuggingFace embedding utilities for build_index and rag_search
- centralize embedding dimension constant

## Testing
- `pytest`
- `python py/ai_engine/tools/rag_search.py`
- `python py/ai_engine/tools/build_index.py` *(fails: PINECONE_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_689e232a85188331add241cc95010df2