### PR TITLE
chore: enforce import ordering and newline in Python modules

### DIFF
--- a/fasal-setu-ai/py/ai_engine/app.py
+++ b/fasal-setu-ai/py/ai_engine/app.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+
 from .schemas.act_request import ActRequest
 from .schemas.act_response import ActResponse
 

--- a/fasal-setu-ai/py/ai_engine/graph/router.py
+++ b/fasal-setu-ai/py/ai_engine/graph/router.py
@@ -1,6 +1,7 @@
 
 from .state import PlannerState, ToolCall
 
+
 def router_node(state: PlannerState) -> PlannerState:
 	# TODO: Replace stub with LangChain LLM-1 planner logic
 	# Compose prompt for LLM-1 and parse output

--- a/fasal-setu-ai/py/ai_engine/graph/state.py
+++ b/fasal-setu-ai/py/ai_engine/graph/state.py
@@ -1,9 +1,7 @@
 
-from typing import Any, Dict, List, Optional, Literal
+from typing import Any, Dict, List, Literal, Optional
+
 from pydantic import BaseModel
-
-
-
 
 # Standardized tool names for LangChain (contract tools only)
 TOOL_NAMES = [

--- a/fasal-setu-ai/py/ai_engine/graph/tools_node.py
+++ b/fasal-setu-ai/py/ai_engine/graph/tools_node.py
@@ -1,15 +1,15 @@
 
 
 
-from .state import PlannerState, ToolCall
 from langchain.tools import Tool
-from ..tools.rag_search import rag_search
-from ..tools.weather_api import weather_outlook
-from ..tools.mandi_api import prices_fetch
-from ..tools.dataset_lookup import calendar_lookup
 
+from ..tools.dataset_lookup import calendar_lookup
+from ..tools.mandi_api import prices_fetch
 from ..tools.pesticide_lookup import pesticide_lookup
+from ..tools.rag_search import rag_search
 from ..tools.storage_find import storage_find
+from ..tools.weather_api import weather_outlook
+from .state import PlannerState, ToolCall
 
 # Register tools with LangChain (contract tools only)
 TOOL_MAP = {

--- a/fasal-setu-ai/py/ai_engine/schemas/act_request.py
+++ b/fasal-setu-ai/py/ai_engine/schemas/act_request.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, Optional
+
 from pydantic import BaseModel
+
 
 class ActRequest(BaseModel):
     query: Optional[str] = None

--- a/fasal-setu-ai/py/ai_engine/schemas/act_response.py
+++ b/fasal-setu-ai/py/ai_engine/schemas/act_response.py
@@ -1,6 +1,9 @@
 from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel
+
 from ..graph.state import ToolCall
+
 
 class ActResponse(BaseModel):
     intent: str

--- a/fasal-setu-ai/py/ai_engine/tools/build_index.py
+++ b/fasal-setu-ai/py/ai_engine/tools/build_index.py
@@ -2,13 +2,14 @@
 """
 build_index.py: Ingests all static JSON/text files from data/static_json/, chunks them (JSON-aware), embeds with llama-text-embed-v2, and upserts to Pinecone index.
 """
-import os
 import json
 import os
 from pathlib import Path
-from typing import List, Dict, Any
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from typing import Any, Dict, List
+
 from dotenv import load_dotenv
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
 load_dotenv()
 
 

--- a/fasal-setu-ai/py/ai_engine/tools/dataset_lookup.py
+++ b/fasal-setu-ai/py/ai_engine/tools/dataset_lookup.py
@@ -1,7 +1,7 @@
 
-import os
 import json
-from typing import Dict, Any
+import os
+from typing import Any, Dict
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), '../../..', 'data', 'static_json', 'crop_calendar')
 

--- a/fasal-setu-ai/py/ai_engine/tools/pesticide_lookup.py
+++ b/fasal-setu-ai/py/ai_engine/tools/pesticide_lookup.py
@@ -1,7 +1,7 @@
 
-import os
 import json
-from typing import Dict, Any
+import os
+from typing import Any, Dict
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), '../../..', 'data', 'static_json', 'pesticides')
 

--- a/fasal-setu-ai/py/ai_engine/tools/rag_search.py
+++ b/fasal-setu-ai/py/ai_engine/tools/rag_search.py
@@ -2,13 +2,15 @@
 rag_search.py: Query Pinecone for top-k similar passages given a query, using local or Pinecone embedder.
 """
 import os
+from typing import Any, Dict
+
 from dotenv import load_dotenv
+
 load_dotenv()
-from typing import Dict, Any
 
 # Use Pinecone's built-in embedder if available (v7+), else fallback to HuggingFaceEmbeddings
 try:
-    from pinecone import Pinecone, EmbeddingModel
+    from pinecone import EmbeddingModel, Pinecone
     EMBEDDER = EmbeddingModel.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")
     def embed_query(text):
         return EMBEDDER.embed_documents([text])[0]

--- a/fasal-setu-ai/py/decision_engine/app.py
+++ b/fasal-setu-ai/py/decision_engine/app.py
@@ -1,6 +1,7 @@
+from typing import Any, Dict
+
 from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import Any, Dict
 
 app = FastAPI(title="Decision Engine")
 

--- a/fasal-setu-ai/py/llm2/app.py
+++ b/fasal-setu-ai/py/llm2/app.py
@@ -1,6 +1,7 @@
+from typing import Any, Dict, List
+
 from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import Any, Dict, List
 
 app = FastAPI(title="LLM-2 Formatter")
 


### PR DESCRIPTION
## Summary
- remove duplicate `import os` and sort imports in `build_index.py`
- sort imports across Python modules
- ensure Python files end with a newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e2331cef483319d752c1a0778c53a