### PR TITLE
feat: enhance tool orchestration and planner prompts

### DIFF
--- a/fasal-setu-ai/contracts/ai_engine.intent.json
+++ b/fasal-setu-ai/contracts/ai_engine.intent.json
@@ -21,9 +21,8 @@
 							"weather_outlook",
 							"prices_fetch",
 							"calendar_lookup",
-							"variety_lookup",
-							"policy_match",
-							"pesticide_lookup",
+                                                        "policy_match",
+                                                        "pesticide_lookup",
 							"storage_find",
                                                         "rag_search"
 						]

--- a/fasal-setu-ai/py/ai_engine/app.py
+++ b/fasal-setu-ai/py/ai_engine/app.py
@@ -15,8 +15,9 @@ def ping():
 
 @app.post("/act", response_model=ActResponse)
 def act_endpoint(request: ActRequest):
-    # Build initial planner state
-    state = PlannerState(query=request.query or "", profile=request.profile)
+    # Build initial planner state, respecting mode
+    profile = request.profile if request.mode != "public_advisor" else None
+    state = PlannerState(query=request.query or "", profile=profile)
     # Run planner LLM
     state = router_node(state)
     # Run tools
@@ -26,7 +27,7 @@ def act_endpoint(request: ActRequest):
         intent=state.intent,
         decision_template=state.decision_template,
         missing=state.missing,
-        tool_calls=[call for call in state.pending_tool_calls] if state.pending_tool_calls else None,
+        tool_calls=state.tool_calls,
         facts=state.facts,
     )
     return response

--- a/fasal-setu-ai/py/ai_engine/graph/state.py
+++ b/fasal-setu-ai/py/ai_engine/graph/state.py
@@ -1,38 +1,41 @@
 
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # Standardized tool names for LangChain (contract tools only)
 TOOL_NAMES = [
-	"weather_outlook",
-	"prices_fetch",
-	"calendar_lookup",
-	"policy_match",
-	"pesticide_lookup",
-	"storage_find",
-	"rag_search"
+        "weather_outlook",
+        "prices_fetch",
+        "calendar_lookup",
+        "policy_match",
+        "pesticide_lookup",
+        "storage_find",
+        "rag_search",
+        "soil_api",
 ]
 
 
 class ToolCall(BaseModel):
-	tool: Literal[
-		"weather_outlook",
-		"prices_fetch",
-		"calendar_lookup",
-		"policy_match",
-		"pesticide_lookup",
-		"storage_find",
-		"rag_search"
-	]
-	args: Dict[str, Any]
+        tool: Literal[
+                "weather_outlook",
+                "prices_fetch",
+                "calendar_lookup",
+                "policy_match",
+                "pesticide_lookup",
+                "storage_find",
+                "rag_search",
+                "soil_api",
+        ]
+        args: Dict[str, Any]
 
 
 class PlannerState(BaseModel):
-	query: str
-	profile: Optional[Dict[str, Any]] = None
-	intent: Optional[str] = None
-	decision_template: Optional[str] = None
-	pending_tool_calls: List[ToolCall] = []
-	facts: Dict[str, Any] = {}
-	missing: Optional[List[str]] = None
+        query: str
+        profile: Optional[Dict[str, Any]] = None
+        intent: Optional[str] = None
+        decision_template: Optional[str] = None
+        pending_tool_calls: List[ToolCall] = Field(default_factory=list)
+        tool_calls: List[ToolCall] = Field(default_factory=list)
+        facts: Dict[str, Any] = Field(default_factory=dict)
+        missing: Optional[List[str]] = None

--- a/fasal-setu-ai/py/ai_engine/graph/tools_node.py
+++ b/fasal-setu-ai/py/ai_engine/graph/tools_node.py
@@ -14,6 +14,8 @@ except ImportError:
 from ..tools.dataset_lookup import calendar_lookup
 from ..tools.pesticide_lookup import pesticide_lookup
 from ..tools.storage_find import storage_find
+from ..tools.policy_match import policy_match
+from ..tools.soil_api import soil_api
 from .state import PlannerState, ToolCall
 
 # Import weather tool from notebook
@@ -48,28 +50,32 @@ except ImportError:
 
 # Register tools with LangChain (contract tools only)
 TOOL_MAP = {
-	"weather_outlook": weather_outlook,
-	"prices_fetch": prices_fetch,
-	"calendar_lookup": calendar_lookup,
-	"pesticide_lookup": pesticide_lookup,
-	"storage_find": storage_find,
-	"rag_search": rag_search,
+        "weather_outlook": weather_outlook,
+        "prices_fetch": prices_fetch,
+        "calendar_lookup": calendar_lookup,
+        "policy_match": policy_match,
+        "pesticide_lookup": pesticide_lookup,
+        "storage_find": storage_find,
+        "rag_search": rag_search,
+        "soil_api": soil_api,
 }
 
 def tools_node(state: PlannerState) -> PlannerState:
-	# Iterate over pending_tool_calls and execute each tool using TOOL_MAP
-	for call in state.pending_tool_calls:
-		tool = TOOL_MAP.get(call.tool)
-		if tool:
-			# Support both LangChain Tool/StructuredTool and plain function
-			if hasattr(tool, "invoke"):
-				result = tool.invoke(call.args)
-			elif hasattr(tool, "run"):
-				result = tool.run(call.args)
-			else:
-				result = tool(call.args)
-			state.facts[call.tool] = result
-		else:
-			state.facts[call.tool] = {"error": "Tool not found"}
-	state.pending_tool_calls = []  # Clear after execution
-	return state
+        executed_calls = list(state.pending_tool_calls)
+        # Iterate over pending_tool_calls and execute each tool using TOOL_MAP
+        for call in executed_calls:
+                tool = TOOL_MAP.get(call.tool)
+                if tool:
+                        # Support both LangChain Tool/StructuredTool and plain function
+                        if hasattr(tool, "invoke"):
+                                result = tool.invoke(call.args)
+                        elif hasattr(tool, "run"):
+                                result = tool.run(call.args)
+                        else:
+                                result = tool(call.args)
+                        state.facts[call.tool] = result
+                else:
+                        state.facts[call.tool] = {"error": "Tool not found"}
+        state.tool_calls.extend(executed_calls)
+        state.pending_tool_calls = []  # Clear after execution
+        return state

--- a/fasal-setu-ai/py/ai_engine/llm1agentinstructions.instructions.md
+++ b/fasal-setu-ai/py/ai_engine/llm1agentinstructions.instructions.md
@@ -32,7 +32,7 @@ py/ai_engine/
     mandi_api.py           # live mandi prices
     dataset_lookup.py      # local crop calendar/policy/etc lookup
     soil_api.py            # optional soil lookup
-    (add variety_lookup.py, policy_match.py, pesticide_lookup.py, storage_find.py as needed)
+    (add policy_match.py, pesticide_lookup.py, storage_find.py as needed)
 contracts/
   ai_engine.intent.json       # schema for planner output
   ai_engine.facts_bundle.json # schema for aggregated facts
@@ -73,7 +73,7 @@ Prices fetch (mandi_api.py): state, district, commodity, date range → price ro
 
 Dataset lookup (dataset_lookup.py): access data/static_json/ for crop calendars, pesticides, policy, soil, storage, etc.
 
-Add specialized wrappers (variety_lookup.py, policy_match.py, pesticide_lookup.py, storage_find.py, soil_api.py) that return structured data + source_stamp.
+Add specialized wrappers (policy_match.py, pesticide_lookup.py, storage_find.py, soil_api.py) that return structured data + source_stamp.
 
 Each tool exposes a callable returning {data, source_stamp}; validate inputs/output against a small schema.
 

--- a/fasal-setu-ai/py/ai_engine/prompts/instruction.txt
+++ b/fasal-setu-ai/py/ai_engine/prompts/instruction.txt
@@ -1,0 +1,10 @@
+Given a farmer's query and profile, output a JSON object with:
+- intent: one of {intents}
+- decision_template: one of {templates}
+- missing: (optional) list of missing fields
+- tool_calls: array of {tool, args} to fetch facts needed for the decision
+
+Query: {query}
+Profile: {profile}
+
+Respond ONLY with a JSON object with keys: intent, decision_template, missing (optional), tool_calls.

--- a/fasal-setu-ai/py/ai_engine/prompts/system.txt
+++ b/fasal-setu-ai/py/ai_engine/prompts/system.txt
@@ -1,0 +1,1 @@
+You are the LLM-1 planner for a farm advisory system.

--- a/fasal-setu-ai/py/ai_engine/schemas/act_request.py
+++ b/fasal-setu-ai/py/ai_engine/schemas/act_request.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal
 
 from pydantic import BaseModel
 
 
 class ActRequest(BaseModel):
-    query: Optional[str] = None
-    profile: Optional[Dict[str, Any]] = None
+    query: str | None = None
+    profile: Dict[str, Any] | None = None
+    mode: Literal["public_advisor", "my_farm"] | None = None

--- a/fasal-setu-ai/py/ai_engine/schemas/act_response.py
+++ b/fasal-setu-ai/py/ai_engine/schemas/act_response.py
@@ -1,13 +1,13 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-from ..graph.state import ToolCall
+from graph.state import ToolCall
 
 
 class ActResponse(BaseModel):
     intent: str
     decision_template: str
-    missing: Optional[List[str]] = None
-    tool_calls: Optional[List[ToolCall]] = None
+    missing: List[str] | None = None
+    tool_calls: List[ToolCall] = Field(default_factory=list)
     facts: Dict[str, Any]

--- a/fasal-setu-ai/py/ai_engine/tools/policy_match.py
+++ b/fasal-setu-ai/py/ai_engine/tools/policy_match.py
@@ -1,1 +1,27 @@
+"""Policy match tool.
+
+This module provides a stub for matching farmer profiles against
+available credit or subsidy policies. The real implementation should
+call an external policy matching service.
+
+TODO:
+    * Integrate with the actual policy matching endpoint.
+    * Define argument and response schemas.
+"""
+
+from typing import Any, Dict
+
+
+def policy_match(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Stub implementation of the policy match tool.
+
+    Args:
+        args: Parameters describing the farmer profile.
+
+    Returns:
+        A dictionary with ``data`` and ``source_stamp`` keys.
+    """
+
+    # TODO: Replace with call to real service
+    return {"data": [], "source_stamp": "policy_match_stub"}
 

--- a/fasal-setu-ai/py/ai_engine/tools/soil_api.py
+++ b/fasal-setu-ai/py/ai_engine/tools/soil_api.py
@@ -1,1 +1,27 @@
+"""Soil API lookup tool.
+
+This module exposes a stub that simulates soil information retrieval.
+In production, this should call an external API that returns soil
+properties for a given location.
+
+TODO:
+    * Connect to the real soil data endpoint.
+    * Validate request arguments and response structure.
+"""
+
+from typing import Any, Dict
+
+
+def soil_api(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Stub implementation of the soil API lookup.
+
+    Args:
+        args: Input parameters such as coordinates or plot identifiers.
+
+    Returns:
+        A dictionary with ``data`` and ``source_stamp`` keys.
+    """
+
+    # TODO: Replace with an actual API call
+    return {"data": {}, "source_stamp": "soil_api_stub"}
 


### PR DESCRIPTION
## Summary
- extend `/act` API with optional mode and return executed tool calls
- expand planner state and tools node to handle new policy and soil tools, dropping variety lookup
- load planner prompts from templates

## Testing
- `pytest` *(fails: cannot import name 'build_index' or 'rag_search' from 'ai_engine.tools')*

------
https://chatgpt.com/codex/tasks/task_e_689f50e6f6f883318e4dcd1d51d757e6